### PR TITLE
Use symbols guaranteed to be contiguous in memory for the `alias` test

### DIFF
--- a/regression/alias.c
+++ b/regression/alias.c
@@ -183,7 +183,7 @@ int test10(void)
    assumed to be different.  Otherwise, this function is optimized into
    an infinite loop! */
 
-int ta[1], tb[1];
+int ta[1]={42}, tb[1]={33};
 
 char * test11(void)
 {


### PR DESCRIPTION
On certain architectures/linkers, symbols introduced by the "comm" directive are not necessarily in the same order in the object code as in the assembly code.

Use instead variables in the data segment: contiguous symbols in the data segment will be in contiguous in the object code.